### PR TITLE
fix(start): restore most recent backup

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -209,6 +209,7 @@ if [ "$am_arkAutoUpdateOnStart" != "true" ]; then
   fi
 fi
 
+arkmanager restore
 arkmanager start --no-background --verbose &
 arkmanpid=$!
 wait $arkmanpid


### PR DESCRIPTION
we should restore the most recent backup to avoid file corruption